### PR TITLE
fix: update repo name in content, so binder works again

### DIFF
--- a/tutorial/intro-data-science/Rmd/01-intro-data-science.Rmd
+++ b/tutorial/intro-data-science/Rmd/01-intro-data-science.Rmd
@@ -36,7 +36,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/01b-filter.Rmd
+++ b/tutorial/intro-data-science/Rmd/01b-filter.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/01c-arrange.Rmd
+++ b/tutorial/intro-data-science/Rmd/01c-arrange.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/01d-mutate.Rmd
+++ b/tutorial/intro-data-science/Rmd/01d-mutate.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/01f-wrap-up.Rmd
+++ b/tutorial/intro-data-science/Rmd/01f-wrap-up.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/02a-intro-data-viz.Rmd
+++ b/tutorial/intro-data-science/Rmd/02a-intro-data-viz.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/02b-geoms.Rmd
+++ b/tutorial/intro-data-science/Rmd/02b-geoms.Rmd
@@ -30,7 +30,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/02c-aesthetics.Rmd
+++ b/tutorial/intro-data-science/Rmd/02c-aesthetics.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/02d-facets.Rmd
+++ b/tutorial/intro-data-science/Rmd/02d-facets.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/03a-summarize.Rmd
+++ b/tutorial/intro-data-science/Rmd/03a-summarize.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/03b-group-by.Rmd
+++ b/tutorial/intro-data-science/Rmd/03b-group-by.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/03c-summary-viz.Rmd
+++ b/tutorial/intro-data-science/Rmd/03c-summary-viz.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/04a-line-plots.Rmd
+++ b/tutorial/intro-data-science/Rmd/04a-line-plots.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/04b-barcharts.Rmd
+++ b/tutorial/intro-data-science/Rmd/04b-barcharts.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/04c-histograms.Rmd
+++ b/tutorial/intro-data-science/Rmd/04c-histograms.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/04d-boxplot.Rmd
+++ b/tutorial/intro-data-science/Rmd/04d-boxplot.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
     useStorage: 1

--- a/tutorial/intro-data-science/Rmd/99e-select.Rmd
+++ b/tutorial/intro-data-science/Rmd/99e-select.Rmd
@@ -20,7 +20,7 @@ jupyter:
     name: venv-intro-to-siuba
   purview:
     branch: master
-    repo: machow/purview
+    repo: machow/intro-to-siuba
     url: https://mybinder.org
     useBinder: 1
 ---


### PR DESCRIPTION
I think mybinder may have changed its behavior slightly. This repo was originally named purview, then the name was changed to intro-to-siuba. Mybinder seemed to work fine, but recently has been complaining about not finding purview. Changed code to reference machow/intro-to-siuba instead.